### PR TITLE
Add missing flags to CI test instructions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -164,8 +164,6 @@ int main()
     IotSdk_Cleanup();
 
     tr_info("Done");
-    while (true) {
-        ThisThread::sleep_for(1000);
-    }
+
     return 0;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/
 
 To run the test, use following command after you build the example:
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-aws.bin --compare-log tests\aws.log
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-aws.bin --compare-log tests\aws.log --baud-rate=115200 --sync=0
 ```
 
 


### PR DESCRIPTION
Note: `--sync=0` is needed because examples, unlike Greentea tests, are not initiated by preambles (input strings via serial).