### PR TITLE
Add Unubscribe to topic

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -157,6 +157,15 @@ int main()
         }
     }
 
+    /* Unubscribe to the topic. */
+    auto unsub_status =  IotMqtt_UnsubscribeSync(connection, &subscription,
+                                                 /* subscription count */ 1, /* flags */ 0,
+                                                 /* timeout ms */ MQTT_TIMEOUT_MS );
+
+    if (unsub_status != IOT_MQTT_SUCCESS) {
+        tr_error("AWS Sdk: Unsubscribe failed with : %u", unsub_status);
+    }
+
     /* Close the MQTT connection. */
     IotMqtt_Disconnect(connection, 0);
 

--- a/mbed-client-for-aws.lib
+++ b/mbed-client-for-aws.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-for-aws.git#8ed6606e142e338a3cd27932138c984120d86e65
+https://github.com/ARMmbed/mbed-client-for-aws.git#efa2b16ff7b5710619d1474f5c2addc5f22f08cb


### PR DESCRIPTION
Add Unubscribe to topic before closing the MQTT connection.
This prevents a race condition which triggers an assert in _mqttOperation_tryDestroy due to a null parameter been passed. 

This PR, in addition to https://github.com/ARMmbed/mbed-client-for-aws/pull/17, allows the example to successfully run at different baud rates (tested with 115200 and 9600).