### PR TITLE
Compile for more supported targets in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,7 @@ jobs:
           cd mbed-os-example-for-aws
           mbed deploy
           mbed compile -t GCC_ARM -m K64F
+          mbed compile -t GCC_ARM -m DISCO_L475VG_IOT01A
+          mbed compile -t GCC_ARM -m NUCLEO_F429ZI
+          mbed compile -t GCC_ARM -m EP_AGORA
 


### PR DESCRIPTION
The initially agreed targets are K64F, DISCO_L475VG_IOT01A and NUCLEO_F429ZI. Support for EP_AGORA has recently been
added by the community.