### PR TITLE
Use the new AWS client in the example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,14 @@ matrix:
         - pip install future==0.16.0
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
+        # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
+        - >-
+          git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git;
+        - >-
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-for-aws)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
@@ -12,15 +12,13 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 add_subdirectory(${MBED_PATH})
 add_subdirectory(mbed-client-for-aws)
 
-if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+if("-DMBED_CONF_ISM43362_PROVIDE_DEFAULT=1" IN_LIST MBED_CONFIG_DEFINITIONS)
     add_subdirectory(wifi-ism43362)
 endif()
 
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
-
-mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
@@ -34,7 +32,7 @@ target_sources(${APP_TARGET}
         main.cpp
 )
 
-if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+if("-DMBED_CONF_ISM43362_PROVIDE_DEFAULT=1" IN_LIST MBED_CONFIG_DEFINITIONS)
     target_link_libraries(${APP_TARGET}
         PRIVATE
             wifi-ism43362
@@ -44,8 +42,6 @@ endif()
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
-        mbed-netsocket
-        mbed-mbedtls
         mbed-client-for-aws
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ target_include_directories(${APP_TARGET}
 target_sources(${APP_TARGET}
     PRIVATE
         main.cpp
+        demo_mqtt.cpp
+        demo_shadow.cpp
 )
 
 if("-DMBED_CONF_ISM43362_PROVIDE_DEFAULT=1" IN_LIST MBED_CONFIG_DEFINITIONS)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # Mbed OS example for AWS cloud
 
-The example project is part of the [Arm Mbed OS Official Examples](https://os.mbed.com/code/). It contains an application that connects to an AWS MQTT broker and publishes a message every 1 second for 10 seconds or until a message is received.
+The example project is part of the [Arm Mbed OS Official Examples](https://os.mbed.com/code/). It contains two demos:
+* MQTT (default): publishes a message every 1 second for 10 messages or until a message is received.
+* Device Shadow service: retrieves a desired value from the cloud, then reports a string value and then an integer value to the cloud.
 
 You can build the project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli).
 (Note: To see a rendered example you can import into the Arm Online Compiler, please see our [import quick start](https://os.mbed.com/docs/mbed-os/latest/quick-start/online-with-the-online-compiler.html#importing-the-code).)
@@ -60,6 +62,8 @@ Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build sys
 
 ## Building and running
 
+### MQTT demo (default)
+
 1. If using WiFi (e.g. on DISCO_L475VG_IOT01A), enter your network's SSID and password in [`mbed_app.json`](./mbed_app.json) (see [here](https://github.com/ARMmbed/mbed-os-example-wifi/blob/master/README.md#getting-started)). Keep any existing `\"`s. (If you use a different WiFi-enabled target, you may need to manually import its WiFi driver as described [here](https://github.com/ARMmbed/mbed-os-example-wifi#supported-hardware).)
 
 1. For Ethernet (e.g on K64F), connect a cable to the port.
@@ -91,34 +95,62 @@ Depending on the target, you can build the example project with the `GCC_ARM` or
 $ mbed compile -S
 ```
 
+### Device Shadow demo
+
+Before running this demo, go to the AWS IoT Core console. In _Test_ -> _Subscribe to a topic_, subscribe to `$aws/things/<your thing>/shadow/#` (the `#` is a wildcard) on the AWS to monitor all Device Shadow updates. Then in _Publish to a topic_, publish to `$aws/things/<your thing>/shadow/update` the following payload:
+
+```json
+{
+  "state": {
+    "desired": {
+      "DemoNumber": 200
+    }
+  }
+}
+```
+
+Build with the same steps as the MQTT demo, but also set `aws-client.shadow` to `true` in [`mbed_app.json`](./mbed_app.json) before compilation.
+
 ## Expected output
+
+### MQTT demo (default)
 
 Once the example starts to run, you can [monitor a serial terminal](https://os.mbed.com/docs/mbed-os/v6.0/tutorials/serial-comm.html) to see that the device connects to your network, exchanges some TLS handshakes, connects to AWS and publishes to the topic you just subscribed. This can be seen on the AWS console as incoming messages.
 
 The application publishes a message every second for 10 seconds, or until it receives a message from the cloud:
 ```
-[INFO][Main]: sending warning message: Warning: Only 10 second(s) left to say your name !
-[INFO][Main]: sending warning message: Warning: Only 9 second(s) left to say your name !
-[INFO][Main]: sending warning message: Warning: Only 8 second(s) left to say your name !
-[INFO][Main]: sending warning message: Warning: Only 7 second(s) left to say your name !
+[INFO][Main]: Publishing "10 messages left to send, or until we receive a reply" to topic <your topic>
+[INFO][Main]: Message sent successfully
+[INFO][Main]: Publishing "9 messages left to send, or until we receive a reply" to topic <your topic>
+[INFO][Main]: Message sent successfully
+[INFO][Main]: Publishing "8 messages left to send, or until we receive a reply" to topic <your topic>
+[INFO][Main]: Message sent successfully
 ```
 
-You can send a message to your device via the AWS IoT console (Test -> Publish to a topic). Use the same topic name you set in `aws-mqtt-topic.value` in [`mbed_app.json`](./mbed_app.json).
+You can send a message to your device via the AWS IoT Core console (_Test_ -> _Publish to a topic_). Use the same topic name you set in `aws-mqtt-topic.value` in [`mbed_app.json`](./mbed_app.json). Use the existing JSON structure and set "message" to one you want to send.
 
-On receipt of a message, the application displays on the console the message prefixed with `Hello␣`.
+On receipt of a message, the application displays on the console the message you sent via the AWS IoT Core console.
+
+### Device Shadow demo
+
+The following will be printed to the serial:
+```
+[INFO][Main]: Device Shadow document downloaded
+[INFO][Main]: Desired value of DemoNumber: <value set on the AWS console>
+[INFO][Main]: Device Shadow reported string value published
+[INFO][Main]: Device Shadow reported integer value published
+```
 
 ## Troubleshooting
 If you have problems, you can review the [documentation](https://os.mbed.com/docs/latest/tutorials/debugging.html) for suggestions on what could be wrong and how to fix it.
 
 ## Related Links
 
-* [Mbed OS Stats API](https://os.mbed.com/docs/latest/apis/mbed-statistics.html).
+* [Mbed client for AWS IoT Core](https://github.com/ARMmbed/mbed-client-for-aws)
+* [AWS IoT Core](https://aws.amazon.com/iot-core/)
 * [Mbed OS Configuration](https://os.mbed.com/docs/latest/reference/configuration.html).
 * [Mbed OS Serial Communication](https://os.mbed.com/docs/latest/tutorials/serial-communication.html).
-* [Mbed OS bare metal](https://os.mbed.com/docs/mbed-os/latest/reference/mbed-os-bare-metal.html).
 * [Mbed boards](https://os.mbed.com/platforms/).
-* [AWS IoT Core](https://aws.amazon.com/iot-core/)
-* [AWS IoT Core - Embedded C SDK](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v4_beta)
 
 ### License and contributions
 

--- a/README.md
+++ b/README.md
@@ -7,22 +7,18 @@ The example project is part of the [Arm Mbed OS Official Examples](https://os.mb
 You can build the project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli).
 (Note: To see a rendered example you can import into the Arm Online Compiler, please see our [import quick start](https://os.mbed.com/docs/mbed-os/latest/quick-start/online-with-the-online-compiler.html#importing-the-code).)
 
-## Downloading this project
-1. [Install Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+## Mbed OS build tools
 
-1. Clone this repository on your system, and change the current directory to where the project was cloned:
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-for-aws`
+1. Change the current directory to where the project was imported.
 
-    ```
-    $ git clone https://github.com/ARMmbed/mbed-os-example-for-aws.git && cd mbed-os-example-for-aws
-    $ mbed deploy
-    ```
-
-    Alternatively, you can download the example project with Arm Mbed CLI using the `import` subcommand:
-
-    ```
-    $ mbed import mbed-os-example-for-aws && cd mbed-os-example-for-aws
-    ```
-
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-for-aws`
+1. Change the current directory to where the project was imported.
 
 ## Configuring the AWS IoT Core service
 
@@ -71,12 +67,23 @@ You can build the project with all supported [Mbed OS build tools](https://os.mb
 1. Connect a USB cable between the USB port on the board and the host computer.
 
 1. <a name="build_cmd"></a> Run the following command to build the example project, program the microcontroller flash memory, and open a serial terminal:
+
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm --baudrate=115200
     ```
-    $ mbed compile -m detect -t <TOOLCHAIN> --flash --sterm --baud 115200
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm --baudrate=115200
     ```
 
 Alternatively, you can manually copy the binary to the board, which you mount on the host computer over USB.
-The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-for-aws.bin`.
+The binary is located at:
+* **Mbed CLI 2** - `./cmake_build/<TARGET>/<PROFILE>/<TOOLCHAIN>/mbed-os-example-for-aws.bin`</br>
+* **Mbed CLI 1** - `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-for-aws.bin`
 
 Depending on the target, you can build the example project with the `GCC_ARM` or `ARM` toolchain. Run the command below to determine which toolchain supports your target:
 

--- a/demo_mqtt.cpp
+++ b/demo_mqtt.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if !MBED_CONF_AWS_CLIENT_SHADOW
+
+#include "mbed.h"
+#include "mbed-trace/mbed_trace.h"
+#include "rtos/ThisThread.h"
+#include "AWSClient/AWSClient.h"
+
+extern "C" {
+#include "core_json.h"
+}
+
+#define TRACE_GROUP "Main"
+
+static bool reply_received = false;
+
+// Callback when a MQTT message has been added to the topic
+void on_message_callback(
+    const char *topic,
+    uint16_t topic_length,
+    const void *payload,
+    size_t payload_length)
+{
+    char *json_value;
+    size_t value_length;
+    auto ret = JSON_Search((char *)payload, payload_length, "sender", strlen("sender"), &json_value, &value_length);
+    if (ret == JSONSuccess && (strncmp(json_value, "device", strlen("device")) == 0)) {
+        tr_info("Message sent successfully");
+    } else {
+        ret = JSON_Search((char *)payload, payload_length, "message", strlen("message"), &json_value, &value_length);
+        if (ret == JSONSuccess) {
+            reply_received = true;
+            tr_info("Message received from the cloud: \"%.*s\"", value_length, json_value);
+        } else {
+            tr_error("Failed to extract message from the payload: \"%.*s\"", payload_length, (const char *) payload);
+        }
+    }
+}
+
+void demo()
+{
+    AWSClient &client = AWSClient::getInstance();
+
+    // Subscribe to the topic
+    const char topic[] = MBED_CONF_APP_AWS_MQTT_TOPIC;
+    int ret = client.subscribe(topic, strlen(topic));
+    if (ret != MBED_SUCCESS) {
+        tr_error("AWSClient::subscribe() failed");
+        return;
+    }
+
+    // Send ten message to the cloud (one per second)
+    // Stop when we receive a cloud-to-device message
+    char payload[128];
+    for (int i = 0; i < 10; i++) {
+        if (reply_received) {
+            // If we have received a message from the cloud, don't send more messeges
+            break;
+        }
+
+        // The MQTT protocol does not distinguish between senders,
+        // so we add a "sender" attribute to the payload
+        const char base_message[] = "messages left to send, or until we receive a reply";
+        sprintf(payload, "{\n"
+                "    \"sender\": \"device\",\n"
+                "    \"message\": \"%d %s\"\n"
+                "}",
+                10 - i, base_message);
+        tr_info("Publishing \"%d %s\" to topic \"%s\"", 10 - i, base_message, topic);
+        ret = client.publish(
+                  topic,
+                  strlen(topic),
+                  payload,
+                  strlen(payload)
+              );
+        if (ret != MBED_SUCCESS) {
+            tr_error("AWSClient::publish() failed");
+            goto unsubscribe;
+        }
+
+        rtos::ThisThread::sleep_for(1s);
+    }
+
+    // If the user didn't manage to send a cloud-to-device message earlier,
+    // let's wait until we receive one
+    while (!reply_received) {
+        // Continue to receive messages in the communication thread
+        // which is internally created and maintained by the Azure SDK.
+        sleep();
+    }
+
+unsubscribe:
+    // Unsubscribe from the topic
+    ret = client.unsubscribe(topic, strlen(topic));
+    if (ret != MBED_SUCCESS) {
+        tr_error("AWSClient::unsubscribe() failed");
+    }
+}
+
+#endif // !MBED_CONF_AWS_CLIENT_SHADOW

--- a/demo_shadow.cpp
+++ b/demo_shadow.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if MBED_CONF_AWS_CLIENT_SHADOW
+
+#include "mbed.h"
+#include "mbed-trace/mbed_trace.h"
+#include "AWSClient/AWSClient.h"
+
+extern "C" {
+#include "core_json.h"
+}
+
+#define TRACE_GROUP "Main"
+
+// This should not be called for the Device Shadow demo -
+// Device Shadow messages are internally consumed by the client
+void on_message_callback(
+    const char *topic,
+    uint16_t topic_length,
+    const void *payload,
+    size_t payload_length)
+{
+    tr_warning(
+        "Message received on non-shadow topic: %.*s payload: %.*s",
+        topic_length,
+        topic,
+        (const char *) payload_length,
+        payload
+    );
+}
+
+void demo()
+{
+    AWSClient &client = AWSClient::getInstance();
+
+    // Download shadow document
+    auto ret = client.downloadShadowDocument();
+    if (ret == MBED_SUCCESS) {
+        tr_info("Device Shadow document downloaded");
+    } else {
+        tr_error("AWSClient::downloadShadowDocument() failed: %d", ret);
+        return; // cannot continue without downloadShadowDocument()
+    }
+
+    // Get a desired shadow value
+    const char shadow_demo_int_key[] = "DemoNumber";
+    const int shadow_demo_int_value = 100;
+    char *shadow_value;
+    size_t shadow_value_length;
+    ret = client.getShadowDesiredValue(
+        shadow_demo_int_key,
+        strlen(shadow_demo_int_key),
+        &shadow_value,
+        &shadow_value_length
+    );
+    if (ret == MBED_SUCCESS) {
+        tr_info("Desired value of %s: %.*s", shadow_demo_int_key, shadow_value_length, shadow_value);
+    } else {
+        tr_error(
+            "AWSClient::getShadowDesiredValue() failed: %d, "
+            "please ensure you have set a desired value for %s (e.g. using the AWS Console)",
+            ret,
+            shadow_demo_int_key
+        );
+    }
+
+    // Report a string shadow value
+    const char shadow_demo_string_key[] = "DemoName";
+    const char shadow_demo_string_value[] = "mbed-os-example-for-aws";
+    ret = client.publishShadowReportedValue(
+        shadow_demo_string_key,
+        strlen(shadow_demo_string_key),
+        shadow_demo_string_value,
+        strlen(shadow_demo_string_value)
+    );
+    if (ret == MBED_SUCCESS) {
+        tr_info("Device Shadow reported string value published");
+    } else {
+        tr_error("AWSClient::publishShadowReportedValue() failed: %d", ret);
+    }
+
+    // Report an integer shadow value
+    ret = client.publishShadowReportedValue(
+        shadow_demo_int_key,
+        strlen(shadow_demo_int_key),
+        shadow_demo_int_value
+    );
+    if (ret == MBED_SUCCESS) {
+        tr_info("Device Shadow reported integer value published");
+    } else {
+        tr_error("AWSClient::publishShadowReportedValue() failed: %d", ret);
+    }
+}
+
+#endif // MBED_CONF_AWS_CLIENT_SHADOW

--- a/mbed-client-for-aws.lib
+++ b/mbed-client-for-aws.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-for-aws.git#5f422c9449e5882855b84a26fb55fcc40edb5e6a
+https://github.com/ARMmbed/mbed-client-for-aws.git/#f7f8ad1ed18f42f2da7b0c89f6d2e8803e985894

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -17,13 +17,11 @@
         "*": {
             "mbed-trace.enable": true,
             "mbed-trace.max-level": "TRACE_LEVEL_INFO",
-            "aws-client.log-puts": "aws_iot_puts",
-            "aws-client.log-level-global": "IOT_LOG_INFO",
-            "rtos.main-thread-stack-size": 8192,
-            "rtos.thread-stack-size": 2048,
             "platform.error-filename-capture-enabled": true,
             "platform.stdio-convert-newlines": true,
-            "platform.stdio-baud-rate": 115200
+            "platform.stdio-baud-rate": 115200,
+            "aws-client.shadow": false,
+            "aws-client.aws-sdk-trace": false
         },
         "DISCO_L475VG_IOT01A": {
             "target.network-default-interface-type": "WIFI",

--- a/wifi-ism43362.lib
+++ b/wifi-ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#ee466577559ec733e5d3c88c55517a40cb03f537
+https://github.com/ARMmbed/wifi-ism43362/#3813a4bb8623cc9b0525978748581f60d47142fa


### PR DESCRIPTION
Preceding PR: https://github.com/ARMmbed/mbed-client-for-aws/pull/19 (merged)

This PR
* updates the example to use the new AWS client (preceding PR) based on @boraozgen's contribution
* adds a demo for Device Shadow
* updates & documents Mbed CLI 2/CMake support