### PR TITLE
CMake: Fix project definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(APP_TARGET mbed-os-example-for-aws)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 add_subdirectory(mbed-client-for-aws)
 
@@ -19,8 +21,6 @@ endif()
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE


### PR DESCRIPTION
We were defining the top level CMake project after adding dependencies,
this caused CMake to think mbed-os was the current project.